### PR TITLE
Allow subscribe by tag without form

### DIFF
--- a/includes/class-edd-convertkit.php
+++ b/includes/class-edd-convertkit.php
@@ -268,7 +268,7 @@ class EDD_ConvertKit extends EDD_Newsletter {
 		}
 
 		// Retrieve the global list ID if none is provided
-		if( ! $list_id ) {
+		if( ! $list_id && empty( $tags ) ) {
 			$list_id = edd_get_option( 'edd_convertkit_list', false );
 			if( ! $list_id ) {
 				return false;

--- a/includes/class-edd-convertkit.php
+++ b/includes/class-edd-convertkit.php
@@ -243,6 +243,7 @@ class EDD_ConvertKit extends EDD_Newsletter {
 		}
 
 		if( empty( $lists ) ) {
+			$this->subscribe_email( $user_info, false, false, $tags );
 			return;
 		}
 

--- a/includes/class-edd-convertkit.php
+++ b/includes/class-edd-convertkit.php
@@ -279,6 +279,8 @@ class EDD_ConvertKit extends EDD_Newsletter {
 			'email' => $user_info['email'],
 			'name'  => $user_info['first_name'] . ' ' . $user_info['last_name']
 		) );
+		
+		$return = false;
 
 		$request = wp_remote_post(
 			'https://api.convertkit.com/v3/forms/' . $list_id . '/subscribe?api_key=' . $this->api_key,
@@ -287,29 +289,32 @@ class EDD_ConvertKit extends EDD_Newsletter {
 				'timeout' => 30,
 			)
 		);
-
+		
 		if( ! is_wp_error( $request ) && 200 == wp_remote_retrieve_response_code( $request ) ) {
+			$return = true;	
+		}
 
-			if( ! empty( $tags ) ) {
+		if( ! empty( $tags ) ) {
 
-				foreach( $tags as $tag ) {
+			foreach( $tags as $tag ) {
 
-					$request = wp_remote_post(
-						'https://api.convertkit.com/v3/tags/' . $tag . '/subscribe?api_key=' . $this->api_key,
-						array(
-							'body'    => $args,
-							'timeout' => 15,
-						)
-					);
-
+				$request = wp_remote_post(
+					'https://api.convertkit.com/v3/tags/' . $tag . '/subscribe?api_key=' . $this->api_key,
+					array(
+						'body'    => $args,
+						'timeout' => 15,
+					)
+				);
+				
+				if( ! is_wp_error( $request ) && 200 == wp_remote_retrieve_response_code( $request ) ) {
+					$return = true;	
 				}
 
 			}
 
-			return true;
 		}
 
-		return false;
+		return $return;
 
 	}
 


### PR DESCRIPTION
Updates the subscribe_email function to allow the ability to add a tag to subscriber without subscribing to form. ConvertKit API allows us to subscribe a user to a tag itself and, if the user is already a subscriber, adds the tag to the subscriber. This is useful when the user is already a subscriber and we simply want to add a tag to them rather than subscribing them to a form.

Not sure if I like the $return implementation but haven't decided on a better way to do it yet.